### PR TITLE
add Dockerfile and docker-compose.yml

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+Dockerfile
+node_modules
+docs
+README.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:current-alpine
+
+COPY --chown=1000:1000 .  /app 
+
+RUN cd /app \
+    && npm install \
+    && npm run build
+
+LABEL org.opencontainers.image.source https://github.com/gandlafbtc/nutstash-wallet
+
+WORKDIR /app
+
+EXPOSE 4173/tcp
+
+CMD [ "npm", "run", "preview", "--", "--host" ]

--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@ npm run build
 You can preview the production build with `npm run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://kit.svelte.dev/docs/adapters) for your target environment.
+
+## Run with docker
+
+As an alternative to node/npm one can use [docker](docs/docker.md) to build and run the application.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.7'
+
+services:
+  nutstash:
+    image: nutstash
+    build:
+      context: .
+      dockerfile: Dockerfile
+      platforms:
+        - "linux/amd64"
+        - "linux/arm64"
+    user: "1000:1000"
+    restart: on-failure
+    ports:
+      - "4173:4173"

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,27 @@
+# Docker
+
+Using docker you don't need to install, configure, and manage a node environment.
+
+## Building the app with docker
+
+```shell
+docker build --tag nutstash .
+```
+or
+```shell
+docker-compose --build
+```
+
+## Running the app using docker
+Make sure to have build the app first. If you build the app using `docker-compose`, you should run the app using `docker-compose`. Alternatively if one builds and tags the image using `docker build`, one should run the app using `docker run`.
+
+```shell
+docker run --publish 4173:4173 nutstash
+```
+or
+```shell
+docker-compose up
+```
+
+## Open the app
+After building and running the app, one can go to `http://localhost:4173` to use the app in a browser.


### PR DESCRIPTION
I want to bring nutstash to the umbrel app store and therefor it needs to play nice with docker.

This PR has the benefit that you don't need to install, configure, and manage a node environment if docker is already present.

## Building the app with docker

```shell
docker build --tag nutstash .
```
or
```shell
docker-compose --build
```

## Running the app using docker
Make sure to have build the app first. If you build the app using `docker-compose`, you should run the app using `docker-compose`. Alternatively if one builds and tags the image using `docker build`, one should run the app using `docker run`.

```shell
docker run --publish 4173:4173 nutstash
```
or
```shell
docker-compose up
```

## Open the app
After building and running the app, one can go to `http://localhost:4173` to use the app in a browser.