### PR TITLE
allow for recognizing hash in url as token on load

### DIFF
--- a/src/comp/wallet/Receiving.svelte
+++ b/src/comp/wallet/Receiving.svelte
@@ -115,9 +115,9 @@
 			const mintIndex = $mints.findIndex((m) => m.mintURL === mint.mintUrl);
 			if (mintIndex > -1) {
 				if ($mints[mintIndex].isAdded) {
-				toast('warning', 'this mint has already been added.', "Didn't add mint!");
-				return;
-			}
+					toast('warning', 'this mint has already been added.', "Didn't add mint!");
+					return;
+				}
 
 				const allMints = $mints;
 				const [ newMint ] = allMints.splice(mintIndex, 1);

--- a/src/comp/wallet/Receiving.svelte
+++ b/src/comp/wallet/Receiving.svelte
@@ -20,7 +20,7 @@
 
 	let mint: Mint | undefined;
 	let mintId: string = '';
-	let encodedToken: string = '';
+	export let encodedToken: string = '';
 	let isValid = false;
 	let isLoading = false;
 	let amount = 0;
@@ -79,7 +79,7 @@
 	};
 
 	const findMintById = (mints: Array<Mint>, id: string) => {
-		return mints.filter((m) => m.keysets.includes(id))[0];
+		return mints.filter((m) => m.isAdded && m.keysets.includes(id))[0];
 	};
 
 	const validateToken = () => {
@@ -112,8 +112,18 @@
 	const trustMint = async () => {
 		const mint = new CashuMint(mintToAdd);
 		try {
-			if ($mints.filter((m) => m.mintURL === mint.mintUrl).length > 0) {
+			const mintIndex = $mints.findIndex((m) => m.mintURL === mint.mintUrl);
+			if (mintIndex > -1) {
+				if ($mints[mintIndex].isAdded) {
 				toast('warning', 'this mint has already been added.', "Didn't add mint!");
+				return;
+			}
+
+				const allMints = $mints;
+				const [ newMint ] = allMints.splice(mintIndex, 1);
+				newMint.isAdded = true;
+				mints.set([newMint, ...allMints]);
+				mintToAdd = '';
 				return;
 			}
 			isLoadingMint = true;
@@ -168,6 +178,10 @@
 			return Promise.resolve(nip19.npubEncode($nostrPubKey));
 		}
 	};
+
+	if (encodedToken) {
+		validateToken();
+	}
 </script>
 
 <div class="flex flex-col gap-2">

--- a/src/comp/wallet/Wallet.svelte
+++ b/src/comp/wallet/Wallet.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { page } from '$app/stores';
 	import { token } from '../../stores/tokens';
 	import { mints } from '../../stores/mints';
 	import Sending from './Sending.svelte';
@@ -11,11 +12,27 @@
 	import { toast } from '../../stores/toasts';
 	import { pendingTokens } from '../../stores/pendingtokens';
 	 import ScanLn from '../elements/ScanLN.svelte';
+	import { goto } from '$app/navigation';
 
 	let active = 'base';
-	let scannedlnInvoice = ''
+	let scannedlnInvoice = '';
+	let encodedToken = '';
 
 	onMount(() => {
+		if($page.url.hash) {
+			active = 'receive'
+			const originalUrl = $page.url.toString();
+			const newUrl = originalUrl.split('#')[0];
+			goto(newUrl, { 
+				replaceState: true,
+				keepFocus: true,
+				noScroll: true,
+			}).then(() => {
+				history.replaceState(null, '', originalUrl);
+			});
+			encodedToken = $page.url.hash.replace(/^#/, '');
+		}
+
 		let isFirst = true;
 		let isFirstPending = true;
 		$mints.forEach(async (mint) => {
@@ -178,7 +195,7 @@
 		<Tokens />
 	</div>
 {:else if active === 'receive'}
-	<Receiving bind:active />
+	<Receiving bind:active encodedToken={encodedToken} />
 {:else if active === 'send'}
 	<Sending bind:active />
 	{:else if active === 'melt'}

--- a/src/comp/wallet/Wallet.svelte
+++ b/src/comp/wallet/Wallet.svelte
@@ -11,7 +11,7 @@
 	import { CashuMint, CashuWallet } from '@gandlaf21/cashu-ts';
 	import { toast } from '../../stores/toasts';
 	import { pendingTokens } from '../../stores/pendingtokens';
-	 import ScanLn from '../elements/ScanLN.svelte';
+	import ScanLn from '../elements/ScanLN.svelte';
 	import { goto } from '$app/navigation';
 
 	let active = 'base';


### PR DESCRIPTION
## Description
Allows importing a cashu token on load via the url hash.

## Changes

- Allows accepting a token even when there are no mints registered
- Will mark a mint as "isAdded" if mint is required for token instead of complaining about the mint already existing.
- `goto` logic ensures that the wallet tab behaves normally after first load. (eg. go to url with hash, hit cancel, go to mint tab, come back to wallet tab -> should not try to add token again)

## PR Tasks

- [x] Open PR
- [x] run `npm run test:unit`
- [x] run `npm run format`
- [ ] 

Note: `npm run format` made a LOT of changes. It changed readme files, and formatted a lot of files which would make this PR hard to read.


