### PR TITLE
dont bring hash back, it is not good for ux, also make onMount async

### DIFF
--- a/src/comp/wallet/Wallet.svelte
+++ b/src/comp/wallet/Wallet.svelte
@@ -18,19 +18,17 @@
 	let scannedlnInvoice = '';
 	let encodedToken = '';
 
-	onMount(() => {
+	onMount(async () => {
 		if ($page.url.hash) {
 			active = 'receive';
 			const originalUrl = $page.url.toString();
 			const newUrl = originalUrl.split('#')[0];
-			goto(newUrl, {
+			encodedToken = $page.url.hash.replace(/^#/, '');
+			await goto(newUrl, {
 				replaceState: true,
 				keepFocus: true,
 				noScroll: true
-			}).then(() => {
-				history.replaceState(null, '', originalUrl);
 			});
-			encodedToken = $page.url.hash.replace(/^#/, '');
 		}
 
 		let isFirst = true;


### PR DESCRIPTION
# Fixes:
- `onMount` supports async methods, this will ensure there are no weird race conditions caused by not using this.
- Restoring the `#token`  in the url does not help with UX because we unconditionally load the receive page.

## Description

{goes here}

## Changes

- ...
- ...
- ...
- ...

## PR Tasks

- [x] Open PR
- [x] run `npm run test:unit`
- [ ] run `npm run format`
- [ ]
