### PR TITLE
Issue #54: better error message when token can't be received

### DIFF
--- a/src/comp/wallet/Receiving.svelte
+++ b/src/comp/wallet/Receiving.svelte
@@ -72,9 +72,14 @@
 			isLoading = false;
 			isComplete = true;
 			toast('success', `${amount} tokens received`, 'Tokens received!');
-		} catch {
+		} catch (error) {
+			console.error(error);
 			isLoading = false;
-			toast('error', 'Tokens could not be received', 'an Error occured');
+			toast(
+				'error',
+				'Tokens are invalid or have already been redeemed',
+				'Tokens could not be received'
+			);
 		}
 	};
 
@@ -164,7 +169,6 @@
 		if ($useExternalNostrKey) {
 			if (browser) {
 				const pubK = await window.nostr?.getPublicKey();
-				console.log(pubK);
 				if (!pubK) {
 					return '';
 				}

--- a/src/comp/wallet/Wallet.svelte
+++ b/src/comp/wallet/Wallet.svelte
@@ -18,19 +18,17 @@
 	let scannedlnInvoice = '';
 	let encodedToken = '';
 
-	onMount(() => {
+	onMount(async () => {
 		if ($page.url.hash) {
 			active = 'receive';
 			const originalUrl = $page.url.toString();
 			const newUrl = originalUrl.split('#')[0];
-			goto(newUrl, {
+			encodedToken = $page.url.hash.replace(/^#/, '');
+			await goto(newUrl, {
 				replaceState: true,
 				keepFocus: true,
 				noScroll: true
-			}).then(() => {
-				history.replaceState(null, '', originalUrl);
 			});
-			encodedToken = $page.url.hash.replace(/^#/, '');
 		}
 
 		let isFirst = true;


### PR DESCRIPTION
# Fixes: #54 

## Description

Changed error message. need better error handling in cashu-ts library to improve this further

## Changes

- changed error message

## PR Tasks

- [x] Open PR
- [x] run `npm run test:unit`
- [x] run `npm run format`
