### PR TITLE
improve loading more entries ux

### DIFF
--- a/src/comp/history/HistoryTable.svelte
+++ b/src/comp/history/HistoryTable.svelte
@@ -2,11 +2,11 @@
 	import { history } from '../../stores/history';
 	import HistoryRow from './HistoryRow.svelte';
 
-	$: page = 5;
+	$: page = 20;
 	$: historySub = $history.slice(0, page);
 
 	const loadMore = () => {
-		page += 5;
+		page += 20;
 	};
 </script>
 
@@ -24,9 +24,18 @@
 			{#each historySub as historyItem, i}
 				<HistoryRow {historyItem} {i} />
 			{/each}
-			<tr class="hover">
-				<!-- svelte-ignore a11y-click-events-have-key-events -->
-				<td colspan="4" class="cursor-pointer w-full" on:click={loadMore}> load more </td>
+			<!-- svelte-ignore a11y-click-events-have-key-events -->
+			<tr class="">
+				<td colspan="2" class="cursor-pointer w-full hover:bg-base-200" on:click={loadMore}>
+					load more
+				</td>
+				<td
+					colspan="2"
+					class="cursor-pointer w-full hover:bg-base-200"
+					on:click={() => (page = 999999)}
+				>
+					load all
+				</td>
 			</tr>
 		</tbody>
 	</table>

--- a/src/comp/tokens/AvailableTokensTable.svelte
+++ b/src/comp/tokens/AvailableTokensTable.svelte
@@ -4,11 +4,11 @@
 	import TokenRow from './TokenRow.svelte';
 
 	$: isPending = true;
-	$: page = 5;
+	$: page = 20;
 	$: tokenSub = isPending ? $pendingTokens.slice(0, page) : $token.slice(0, page);
 
 	const loadMore = () => {
-		page += 5;
+		page += 20;
 	};
 </script>
 
@@ -36,9 +36,18 @@
 			{#each tokenSub as token, i}
 				<TokenRow {token} {i} />
 			{/each}
-			<tr class="hover">
-				<!-- svelte-ignore a11y-click-events-have-key-events -->
-				<td colspan="4" class="cursor-pointer w-full" on:click={loadMore}> load more </td>
+			<!-- svelte-ignore a11y-click-events-have-key-events -->
+			<tr class="">
+				<td colspan="2" class="cursor-pointer w-full hover:bg-base-200" on:click={loadMore}>
+					load more
+				</td>
+				<td
+					colspan="2"
+					class="cursor-pointer w-full hover:bg-base-200"
+					on:click={() => (page = 999999)}
+				>
+					load all
+				</td>
 			</tr>
 		</tbody>
 	</table>

--- a/src/comp/tokens/InboxTable.svelte
+++ b/src/comp/tokens/InboxTable.svelte
@@ -8,13 +8,13 @@
 	import { getAmountForTokenSet } from '../util/walletUtils';
 	import InboxRow from './InboxRow.svelte';
 
-	$: page = 5;
+	$: page = 20;
 	$: nostrMessagesSub = $nostrMessages.slice(0, page);
 
 	let isLoading = false;
 
 	const loadMore = () => {
-		page += 5;
+		page += 20;
 	};
 
 	const receiveAll = async () => {
@@ -117,9 +117,18 @@
 			{#each nostrMessagesSub as nostrMessage, i}
 				<InboxRow {nostrMessage} {i} />
 			{/each}
-			<tr class="hover">
-				<!-- svelte-ignore a11y-click-events-have-key-events -->
-				<td colspan="4" class="cursor-pointer w-full" on:click={loadMore}> load more </td>
+			<!-- svelte-ignore a11y-click-events-have-key-events -->
+			<tr class="">
+				<td colspan="2" class="cursor-pointer w-full hover:bg-base-200" on:click={loadMore}>
+					load more
+				</td>
+				<td
+					colspan="2"
+					class="cursor-pointer w-full hover:bg-base-200"
+					on:click={() => (page = 999999)}
+				>
+					load all
+				</td>
 			</tr>
 		</tbody>
 	</table>

--- a/src/comp/tokens/TokenTable.svelte
+++ b/src/comp/tokens/TokenTable.svelte
@@ -2,11 +2,11 @@
 	import { history } from '../../stores/history';
 	import TokenHistoryRow from './TokenHistoryRow.svelte';
 
-	$: page = 5;
+	$: page = 20;
 	$: historySub = $history.slice(0, page);
 
 	const loadMore = () => {
-		page += 5;
+		page += 20;
 	};
 </script>
 
@@ -27,9 +27,18 @@
 			{#each historySub as historyItem}
 				<TokenHistoryRow {historyItem} />
 			{/each}
-			<tr class="hover">
-				<!-- svelte-ignore a11y-click-events-have-key-events -->
-				<td colspan="4" class="cursor-pointer w-full" on:click={loadMore}> load more </td>
+			<!-- svelte-ignore a11y-click-events-have-key-events -->
+			<tr class="">
+				<td colspan="2" class="cursor-pointer w-full hover:bg-base-200" on:click={loadMore}>
+					load more
+				</td>
+				<td
+					colspan="2"
+					class="cursor-pointer w-full hover:bg-base-200"
+					on:click={() => (page = 999999)}
+				>
+					load all
+				</td>
 			</tr>
 		</tbody>
 	</table>


### PR DESCRIPTION
# Fixes: #50 

## Description

load 20 entries per page and add option to load all entries

## Changes

- changed page load on all lists

## PR Tasks

- [x] Open PR
- [x] run `npm run test:unit`
- [x] run `npm run format`
