### PR TITLE
add github release action

### DIFF
--- a/.github/workflows/ghcr-release.yml
+++ b/.github/workflows/ghcr-release.yml
@@ -1,0 +1,45 @@
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'A version number'
+        required: true
+        type: string
+
+permissions:
+  actions: none
+  checks: none
+  contents: none
+  deployments: none
+  id-token: none
+  issues: none
+  discussions: none
+  packages: write
+  pages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+
+jobs:
+  docker-compose_build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Docker Setup Buildx
+        uses: docker/setup-buildx-action@v2.5.0
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          path: main
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build images with release version ${{ inputs.version }}
+        run: cd main && docker buildx build --platform linux/amd64,linux/arm64 -t "ghcr.io/${{ github.actor }}/nutstash-wallet:${{ inputs.version }}" --push .

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,6 +1,14 @@
 # Docker
 
+One can use the provided docker container hosted on github or alternatively build and run the container from the repository source code. 
+
 Using docker you don't need to install, configure, and manage a node environment.
+
+## Run provided docker container
+
+```shell
+docker run --publish 4173:4173 ghcr.io/gandlafbtc/nutstash-wallet:latest
+```
 
 ## Building the app with docker
 


### PR DESCRIPTION
This PR enables the release of a docker container to GHCR.io as Action. The action needs to be triggered manually. 

The action has one input named "version". (e.g. `latest`, `v0.1.6`)

The resulting container image will be named `ghcr.io/<github repository owner>/nutstash-wallet:<version>`.

Example output: https://github.com/aphex3k/nutstash-wallet/pkgs/container/nutstash-wallet

<img width="1452" alt="image" src="https://user-images.githubusercontent.com/433270/224525842-c640e54d-16d5-408f-8cae-24e3b45569d0.png">
