### PR TITLE
show qr code when revealing token as url.

### DIFF
--- a/src/comp/wallet/Sending.svelte
+++ b/src/comp/wallet/Sending.svelte
@@ -28,6 +28,7 @@
 	import { pendingTokens } from '../../stores/pendingtokens';
 	import ScanNpub from '../elements/ScanNpub.svelte';
 	import { page } from '$app/stores';
+	import QrCodeImage from 'svelte-qrcode-image/QRCodeImage.svelte';
 
 	export let active;
 
@@ -195,9 +196,6 @@
 	<LoadingCenter />
 {:else if encodedToken}
 	<div class="grid grid-cols-1 gap-2">
-		<!-- <div>
-					<QRCodeImage text={encodedToken} scale={3} displayType="canvas" />
-				</div> -->
 		<div class="flex flex-col gap-2">
 			<div class="text-center">
 				<p class="text-xl font-bold text-success">Tokens are ready to be sent!</p>
@@ -233,6 +231,11 @@
 			<span class="label-text">Send as link</span>
 			<input type="checkbox" class="toggle toggle-primary" bind:checked={sendAsLink} />
 		</label>
+		{#if sendAsLink}
+		<div class="flex flex-col items-center">
+			<QrCodeImage text={$page.url.href + '#' + encodedToken} scale={3} displayType="canvas" />
+		</div>
+		{/if}
 		<div class="pt-2 flex flex-col gap-2 items-center w-full">
 			{#if $useNostr}
 				<p class="font-bold">Send via Nostr:</p>


### PR DESCRIPTION
## Description

This change adds a QR code image whenever a token is created to be sent and the "send as link" toggle is turned on.

I found that this would be convenient when face to face for sending people the link without necessarily having their contact details already.

## Changes

- ...
- ...
- ...
- ...

## PR Tasks

- [x] Open PR
- [ ] run `npm run test:unit`
- [ ] run `npm run format`
- [ ]
