### PR TITLE
Fix tag and container port on docker.md

### DIFF
--- a/docs/docker.md
+++ b/docs/docker.md
@@ -7,7 +7,7 @@ Using docker you don't need to install, configure, and manage a node environment
 ## Run provided docker container
 
 ```shell
-docker run --publish 4173:4173 ghcr.io/gandlafbtc/nutstash-wallet:latest
+docker run --publish 4173:3000 ghcr.io/gandlafbtc/nutstash-wallet:0.1.10
 ```
 
 ## Building the app with docker
@@ -27,7 +27,7 @@ docker-compose --build
 Make sure to have build the app first. If you build the app using `docker-compose`, you should run the app using `docker-compose`. Alternatively if one builds and tags the image using `docker build`, one should run the app using `docker run`.
 
 ```shell
-docker run --publish 4173:4173 nutstash
+docker run --publish 4173:3000 nutstash
 ```
 
 or


### PR DESCRIPTION
# Fixes:
1. Change `latest` tag to match version number
2. Correct container port from 4173 to 3000

## Description

Note that either this doc will need to be updated again as versions increment, or a `latest` tag needs to be created.

## PR Tasks

- [x] Open PR
- [ ] run `npm run test:unit`
- [ ] run `npm run format`
